### PR TITLE
#164900426 Admin/Staff (de)activate Accounts

### DIFF
--- a/server/app/controllers/accountController.js
+++ b/server/app/controllers/accountController.js
@@ -1,5 +1,6 @@
 import accounts from '../models/accounts';
 import AccountNumber from '../helpers/accountNumber';
+import Exists from '../helpers/exists';
 
 /**
  * @class AccountController
@@ -40,6 +41,39 @@ class AccountController {
         email: req.user.email,
         type: account.type,
         openingBalance: account.balance,
+      },
+    });
+  }
+
+  /**
+  * @method changeAccountStatus
+  * @description Activates or deactivates a bank account
+  * @param {object} req - The Request Object
+  * @param {object} res - The Response Object
+  * @returns {object} JSON API Response
+  */
+  changeAccountStatus(req, res) {
+    const { status } = req.body;
+
+    const {
+      accountDetails,
+      accountExists,
+    } = Exists.accountExists(parseInt(req.params.accountNumber, 10), true);
+
+    if (!accountExists) {
+      return res.status(404).json({
+        status: res.statusCode,
+        error: `Account with account number ${req.params.accountNumber} does not exist`,
+      });
+    }
+
+    accountDetails.status = status;
+
+    return res.status(200).json({
+      status: res.statusCode,
+      data: {
+        accountNumber: accountDetails.accountNumber,
+        status: accountDetails.status,
       },
     });
   }

--- a/server/app/controllers/userController.js
+++ b/server/app/controllers/userController.js
@@ -77,23 +77,27 @@ class UserController {
       });
     }
 
-    req.user = {
+    const user = {
       id: userDetails.id,
       firstname: userDetails.firstName,
       lastname: userDetails.lastName,
       email: userDetails.email,
     };
 
-    const token = Auth.generateToken(req.user);
+    if (userDetails.type !== 'client') {
+      user.isAdmin = userDetails.isAdmin;
+      user.type = userDetails.type;
+    }
 
+    const token = Auth.generateToken(user);
     return res.status(200).send({
       status: 200,
       data: {
         token,
-        id: req.user.id,
-        firstName: req.user.firstname,
-        lastName: req.user.lastname,
-        email: req.user.email,
+        id: user.id,
+        firstName: user.firstname,
+        lastName: user.lastname,
+        email: user.email,
       },
     });
   }

--- a/server/app/helpers/accountNumber.js
+++ b/server/app/helpers/accountNumber.js
@@ -1,5 +1,3 @@
-import users from '../models/accounts';
-
 /**
  * @class AccountNumber
  * @description Contains methods to generate random account numbers

--- a/server/app/helpers/exists.js
+++ b/server/app/helpers/exists.js
@@ -1,4 +1,5 @@
 import users from '../models/users';
+import accounts from '../models/accounts';
 
 /**
  * @class Exists
@@ -8,7 +9,7 @@ import users from '../models/users';
 class Exists {
   /**
   * @method emailExists
-  * @description Verifies if the user email already exists
+  * @description Verifies if the user email exists
   * @param {*} email - The email to be verified
   * @param {*} returnUser - A boolean value specifying if the user object should be returned
   * @returns {boolean} a boolean value indicating weather the email exist or not
@@ -26,6 +27,29 @@ class Exists {
       return { userDetails, emailExists };
     }
     return emailExists;
+  }
+
+  /**
+  * @method accountExists
+  * @description Verifies if the user account exists
+  * @param {*} accountNumber - The accountNumber to be verified
+  * @param {*} returnAccount - A boolean value specifying if the account object should be returned
+  * @returns {boolean} a boolean value indicating weather the account exists or not
+  * @returns {object} the account object
+  */
+  accountExists(accountNumber, returnAccount) {
+    let accountExists = false;
+    let accountDetails;
+    accounts.forEach((account) => {
+      if (account.accountNumber === accountNumber) {
+        accountDetails = account;
+        accountExists = true;
+      }
+    });
+    if (returnAccount) {
+      return { accountDetails, accountExists };
+    }
+    return accountExists;
   }
 }
 

--- a/server/app/middlewares/authenticateUser.js
+++ b/server/app/middlewares/authenticateUser.js
@@ -1,4 +1,5 @@
 import Auth from '../auth/auth';
+import { isNullOrUndefined } from 'util';
 
 /**
  * @class AuthenticateUser
@@ -20,6 +21,68 @@ class AuthenticateUser {
       const decoded = Auth.verifyToken(token);
 
       req.user = decoded;
+
+      return next();
+    } catch (error) {
+      return res.status(401).send({
+        status: res.statusCode,
+        error: 'Authentication Failed',
+      });
+    }
+  }
+
+  /**
+   * @method verifyStaff
+   * @description verifies the user token to determine if the user is a staff or not
+   * @param {object} req - The Request Object
+   * @param {object} res - The Response Object
+   * @param {object} next - The next Object
+   * @returns {object} JSON API Response
+   */
+  verifyStaff(req, res, next) {
+    try {
+      const token = req.headers.authorization.split(' ')[1];
+      const decoded = Auth.verifyToken(token);
+
+      req.user = decoded;
+
+      if (req.user.type !== 'staff') {
+        return res.status(403).send({
+          status: res.statusCode,
+          error: 'You are not authorized to view this endpoint',
+        });
+      }
+
+      return next();
+    } catch (error) {
+      return res.status(401).send({
+        status: res.statusCode,
+        error: 'Authentication Failed',
+      });
+    }
+  }
+
+  /**
+   * @method verifyAdmin
+   * @description verifies the user token to determine if the user is admin or not
+   * @param {object} req - The Request Object
+   * @param {object} res - The Response Object
+   * @param {object} next - The next Object
+   * @returns {object} JSON API Response
+   */
+  verifyAdmin(req, res, next) {
+    try {
+      const token = req.headers.authorization.split(' ')[1];
+      const decoded = Auth.verifyToken(token);
+
+      req.user = decoded;
+
+      if (!req.user.isAdmin) {
+        return res.status(403).send({
+          status: 403,
+          error: 'You are not authorized to view this endpoint',
+        });
+      }
 
       return next();
     } catch (error) {

--- a/server/app/middlewares/inputValidator.js
+++ b/server/app/middlewares/inputValidator.js
@@ -71,6 +71,28 @@ class InputValidator {
     }
     return next();
   }
+
+  /**
+  * @method validateStatus
+  * @description Validates the account status passed in from the request body
+  * @param {object} req - The Request Object
+  * @param {object} res - The Response Object
+  * @param {function} next - The next function to point to the next middleware
+  * @returns {function} next() - The next function
+  */
+  validateStatus(req, res, next) {
+    const type = { ...req.body };
+    const validate = Schema.editAccountSchema(type);
+    const { error } = validate;
+
+    if (error) {
+      return res.status(400).send({
+        status: res.statusCode,
+        error: error.details[0].message,
+      });
+    }
+    return next();
+  }
 }
 
 const inputValidator = new InputValidator();

--- a/server/app/middlewares/schema.js
+++ b/server/app/middlewares/schema.js
@@ -161,7 +161,7 @@ class Schema {
   }
 
   /**
-  * @method loginSchema
+  * @method createAccountSchema
   * @description Validates the account details from a post request
   * @param {object} account - The account object to be validated
   * @returns {object} An object specifying weather the input was valid or not.
@@ -201,6 +201,40 @@ class Schema {
                 break;
               case 'any.required':
                 err.message = 'initialDeposit is required';
+                break;
+              default:
+                break;
+            }
+          });
+          return errors;
+        }),
+    };
+    return Joi.validate(account, schema);
+  }
+
+  /**
+  * @method editAccountSchema
+  * @description Validates the account status from a post request
+  * @param {object} account - The account object to be validated
+  * @returns {object} An object specifying weather the input was valid or not.
+  */
+  editAccountSchema(account) {
+    const schema = {
+      status: Joi.string().min(6).max(7).required()
+        .regex(/^active$|^dormant$/)
+        .error((errors) => {
+          errors.forEach((err) => {
+            switch (err.type) {
+              case 'any.empty':
+                err.message = 'status cannot be empty!';
+                break;
+              case 'string.min':
+              case 'string.max':
+              case 'string.regex.base':
+                err.message = 'Account \'status\' can only be \'active\' or \'dormant\'';
+                break;
+              case 'any.required':
+                err.message = 'status is required';
                 break;
               default:
                 break;

--- a/server/app/routes/accounts.js
+++ b/server/app/routes/accounts.js
@@ -10,4 +10,9 @@ accountRoutes.post('/',
   AuthenticateUser.verifyUser,
   AccountController.createAccount);
 
+accountRoutes.patch('/:accountNumber',
+  InputValidator.validateStatus,
+  AuthenticateUser.verifyStaff,
+  AccountController.changeAccountStatus);
+
 export default accountRoutes;

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -30,7 +30,7 @@ describe('User Sign Up Tests', () => {
         });
     });
 
-    it('Should return error 400 if firstname is ommited', (done) => {
+    it('Should return 400 if firstname is ommited', (done) => {
       const user = {
         lastname: 'Ngwobia',
         email: 'coolemail1@testmail.com',
@@ -258,6 +258,61 @@ describe('Account Creation Tests', () => {
       chai.request(app)
         .post(`${apiEndPoint}accounts`)
         .send(input)
+        .end((err, res) => {
+          res.should.have.status(400);
+          res.body.should.be.a('object');
+          res.body.should.have.property('error');
+          done();
+        });
+    });
+  });
+});
+
+describe('Account Status change Tests', () => {
+  describe(`PATCH ${apiEndPoint}accounts/:accountNumber`, () => {
+    it('Should edit account status successfully', (done) => {
+      const login = {
+        email: 'kenny_g@gmail.com',
+        password: 'password',
+      };
+
+      chai.request(app)
+        .post(`${userEndPoint}signin`)
+        .send(login)
+        .end((loginErr, loginRes) => {
+          const token = `Bearer ${loginRes.body.data.token}`;
+
+          chai.request(app)
+            .patch(`${apiEndPoint}accounts/5823642528`)
+            .set('Authorization', token)
+            .send({ status: 'dormant' })
+            .end((err, res) => {
+              res.should.have.status(200);
+              res.body.should.be.a('object');
+              res.body.should.have.property('data');
+              res.body.data.should.be.a('object');
+              res.body.data.should.have.property('status');
+              done();
+            });
+        });
+    });
+
+    it('Should return 400 if new account status isn\'t specified', (done) => {
+      chai.request(app)
+        .patch(`${apiEndPoint}accounts/5823642528`)
+        .send({})
+        .end((err, res) => {
+          res.should.have.status(400);
+          res.body.should.be.a('object');
+          res.body.should.have.property('error');
+          done();
+        });
+    });
+
+    it('Should return 400 if wrong status details are provided', (done) => {
+      chai.request(app)
+        .patch(`${apiEndPoint}accounts/5823642528`)
+        .send({ status: 'domant' })
         .end((err, res) => {
           res.should.have.status(400);
           res.body.should.be.a('object');


### PR DESCRIPTION
#### What does this PR do?
- work on /accounts/<account-number> route
- validate input
- write tests for endpoint

#### Description of task to be completed?
- Admin/Staff should be able to activate or deactivate an account.
- Work on the PATCH ```/accounts/<account-number>```  route

#### How should this be manually tested?
- Clone the repo, CD into it and RUN ```npm install```
- Create a .env file and set the following values according to your needs 
```SECRET_KEY = string```
```SALT_ROUNDS = number```

- Using postman, test the endpoint with the following headers
  -  _key: Content-Type value: application/json_
- And since this is a protected route, user must be an authenticated staff user. So add the following header: you can get a token from ```/auth/signin``` endpoint
  -  _key: Authorization value: JWT _Token_

#### What are the relevant pivotal tracker stories ?
- #164900426